### PR TITLE
Add parser characterization tests and compatibility fixture

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,39 @@
+# Development
+
+## Automated baseline tests
+
+Run the dependency-free characterization suite with:
+
+```sh
+npm test
+```
+
+These characterization tests record FormVault's current parser behavior, including known limitations. They provide a baseline for evaluating future parser changes.
+
+## Test local changes in Chrome
+
+The extension does not need a build step for local development. Chrome can load the repository directly:
+
+1. Open `chrome://extensions` in Chrome.
+2. Turn on **Developer mode**.
+3. Click **Load unpacked** and select the repository root—the directory containing `manifest.json`.
+4. Pin the extension from Chrome's Extensions menu if you want its toolbar button to remain visible.
+5. Open a non-sensitive test page, enter sample form values, and exercise the popup actions.
+
+After changing the source, return to `chrome://extensions` and click the extension's **Reload** button. Refresh any open test tabs so Chrome injects the updated content scripts. Popup changes appear when the popup is reopened, but reloading the extension first is the safest routine.
+
+To use the included test fixture, serve the repository over HTTP from its root:
+
+```sh
+python3 -m http.server 8000
+```
+
+Then open [http://localhost:8000/test.html](http://localhost:8000/test.html). Press `Ctrl+C` in the terminal when finished. Serving the fixture avoids Chrome's additional **Allow access to file URLs** setting.
+
+## Debug extension errors
+
+- Use **Errors** or the **service worker** link on `chrome://extensions` for background errors.
+- Right-click the extension popup and choose **Inspect** for popup errors.
+- Use the test page's DevTools console for content-script errors.
+
+Before publishing changes, confirm that no real form answers, personal information, credentials, production snapshots, or other sensitive data are included in the repository or package.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "FormVault gives users the ability to save form templates and recover lost form data from any webpage.",
   "version": "1.0.0",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test.html
+++ b/test.html
@@ -1,22 +1,59 @@
-<!DOCTYPE html>
-<html>
-<body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>FormVault compatibility fixture</title>
+  </head>
+  <body>
+    <h1>Non-sensitive form compatibility fixture</h1>
+    <p>Use sample values only. This fixture intentionally covers controls the legacy parser mishandles.</p>
 
-<form action="/action_page.php" id="usrform">
-  Name: <input type="text" name="usrname">
-  <input type="submit"> <br>
-  <input type="radio" name="gender" value="male"> Male<br>
-  <input type="radio" name="gender" value="female"> Female<br>
-  <input type="radio" name="gender" value="other"> Other  <br>
-  <input type="checkbox" id="test1" name="test1" value="test1">
-  <label for="test1">Test1</label> <br>
-  <input type="checkbox" id="test2" name="test2" value="test2">
-  <label for="test2">Test2</label> <br>
-  <textarea name="sup"> </textarea>
-</form>
-<br>
+    <form id="primary-form">
+      <label for="full-name">Full name</label>
+      <input id="full-name" name="fullName" type="text" value="Sample Person">
 
-<p>The text area above is outside the form element, but should still be a part of the form.</p>
+      <label for="email">Email</label>
+      <input id="email" name="email" type="email" value="sample@example.test">
 
-</body>
+      <fieldset>
+        <legend>Preferred contact</legend>
+        <label><input name="contact" type="radio" value="email" checked> Email</label>
+        <label><input name="contact" type="radio" value="phone"> Phone</label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Options</legend>
+        <label><input name="updates" type="checkbox" value="news" checked> News</label>
+        <label><input name="updates" type="checkbox" value="events"> Events</label>
+      </fieldset>
+
+      <label for="region">Region</label>
+      <select id="region" name="region">
+        <option value="north">North</option>
+        <option value="south" selected>South</option>
+      </select>
+
+      <label for="notes">Notes</label>
+      <textarea id="notes" name="notes">Sample notes</textarea>
+
+      <fieldset>
+        <legend>Repeated names</legend>
+        <input name="householdMember" value="Alex">
+        <input name="householdMember" value="Sam">
+      </fieldset>
+
+      <label for="unnamed">Control without a name</label>
+      <input id="unnamed" value="Unnamed sample">
+
+      <label for="password">Password (must never be captured)</label>
+      <input id="password" name="password" type="password" value="not-a-real-password">
+    </form>
+
+    <label for="outside-form">Field outside the form</label>
+    <textarea id="outside-form" name="outsideForm">Outside sample</textarea>
+
+    <p id="manual-install-test">
+      To test the defining install scenario, open this page and edit its values before loading the unpacked extension. Save without refreshing this tab.
+    </p>
+  </body>
 </html>

--- a/tests/legacy-baseline.test.js
+++ b/tests/legacy-baseline.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const projectRoot = path.resolve(__dirname, '..');
+
+function loadLegacyParser(classNamesByName = {}) {
+  const context = {
+    DataStack: function DataStack() {},
+    TemplateService: function TemplateService() {},
+    console: { log() {}, warn() {} },
+    $: function jqueryStub(selector) {
+      const match = /^input\[name="(.+)"\]$/.exec(selector);
+      return {
+        attr(attribute) {
+          assert.equal(attribute, 'class');
+          return match ? classNamesByName[match[1]] : undefined;
+        }
+      };
+    }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(projectRoot, 'content_scripts/form-parser.js'), 'utf8'),
+    context,
+    { filename: 'content_scripts/form-parser.js' }
+  );
+  return context;
+}
+
+test('legacy serialization maps ordinary named values and their classes', () => {
+  const { createFormObj } = loadLegacyParser({ fullName: 'form-control' });
+  const result = createFormObj([
+    { name: 'fullName', value: 'Sample Person' }
+  ]);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    fullName: { class: 'form-control', value: 'Sample Person' }
+  });
+});
+
+test('baseline limitation: repeated names collapse to the final serialized value', () => {
+  const { createFormObj } = loadLegacyParser();
+  const result = createFormObj([
+    { name: 'householdMember', value: 'Alex' },
+    { name: 'householdMember', value: 'Sam' }
+  ]);
+
+  assert.equal(Object.keys(result).length, 1);
+  assert.equal(result.householdMember.value, 'Sam');
+});
+
+test('baseline limitation: the parser can only retain controls supplied by serializeArray', () => {
+  const { createFormObj } = loadLegacyParser();
+  const serializedByJquery = [
+    { name: 'fullName', value: 'Sample Person' }
+  ];
+  const result = createFormObj(serializedByJquery);
+
+  assert.equal(result.fullName.value, 'Sample Person');
+  assert.equal(result.updates, undefined);
+  assert.equal(result.outsideForm, undefined);
+});
+
+test('baseline limitation: popup save injection references globals not included in the injected function', () => {
+  const popupSource = fs.readFileSync(path.join(projectRoot, 'popup/popup.js'), 'utf8');
+
+  assert.match(popupSource, /func:\s*saveTemplates/);
+  assert.match(popupSource, /function saveTemplates\(\)[\s\S]*new FormParser/);
+  assert.match(popupSource, /function saveTemplates\(\)[\s\S]*new URLParser/);
+  assert.doesNotMatch(
+    popupSource,
+    /files:\s*\[[^\]]*form-parser\.js[^\]]*\]/
+  );
+});


### PR DESCRIPTION
## Summary

- add dependency-free characterization tests for the existing parser
- document repeated-name and serializeArray limitations without changing runtime behavior
- expand the manual fixture with non-sensitive standard and edge-case controls
- document how to run tests and load FormVault locally in Chrome

## Why

The tests establish the current behavior before parser changes are considered. This makes later compatibility fixes easier to review and helps prevent accidental regressions.

## Checks

- npm test
- git diff --check